### PR TITLE
Fix ARX_MIMO Example lsim transpose issue

### DIFF
--- a/Examples/ARX_MIMO.py
+++ b/Examples/ARX_MIMO.py
@@ -21,8 +21,20 @@ except ImportError:
     from sippy import *
 
 import numpy as np
+import control
 import control.matlab as cnt
 from sippy import functionset as fset
+from distutils.version import StrictVersion
+
+if StrictVersion(control.__version__) >= StrictVersion('0.8.2'):
+	lsim = cnt.lsim
+else:
+	def lsim(sys, U = 0.0, T = None, X0 = 0.0):
+		U_ = U
+		if isinstance(U_, (np.ndarray, list)):
+			U_ = U_.T
+		return cnt.lsim(sys, U_, T, X0)
+		
 
 # generating transfer functions in z-transf.
 var_list = [50., 100., 1.]
@@ -118,22 +130,22 @@ err_inputH = np.zeros((4, npts))
 err_inputH = fset.white_noise_var(npts, var_list)
 
 err_outputH = np.ones((3, npts))
-err_outputH1, Time, Xsim = cnt.lsim(H_sample1, err_inputH[0, :], Time)
-err_outputH2, Time, Xsim = cnt.lsim(H_sample2, err_inputH[1, :], Time)
-err_outputH3, Time, Xsim = cnt.lsim(H_sample3, err_inputH[2, :], Time)
+err_outputH1, Time, Xsim = lsim(H_sample1, err_inputH[0, :], Time)
+err_outputH2, Time, Xsim = lsim(H_sample2, err_inputH[1, :], Time)
+err_outputH3, Time, Xsim = lsim(H_sample3, err_inputH[2, :], Time)
 
-Yout11, Time, Xsim = cnt.lsim(g_sample11, Usim[0, :], Time)
-Yout12, Time, Xsim = cnt.lsim(g_sample12, Usim[1, :], Time)
-Yout13, Time, Xsim = cnt.lsim(g_sample13, Usim[2, :], Time)
-Yout14, Time, Xsim = cnt.lsim(g_sample14, Usim[3, :], Time)
-Yout21, Time, Xsim = cnt.lsim(g_sample21, Usim[0, :], Time)
-Yout22, Time, Xsim = cnt.lsim(g_sample22, Usim[1, :], Time)
-Yout23, Time, Xsim = cnt.lsim(g_sample23, Usim[2, :], Time)
-Yout24, Time, Xsim = cnt.lsim(g_sample24, Usim[3, :], Time)
-Yout31, Time, Xsim = cnt.lsim(g_sample31, Usim[0, :], Time)
-Yout32, Time, Xsim = cnt.lsim(g_sample32, Usim[1, :], Time)
-Yout33, Time, Xsim = cnt.lsim(g_sample33, Usim[2, :], Time)
-Yout34, Time, Xsim = cnt.lsim(g_sample34, Usim[3, :], Time)
+Yout11, Time, Xsim = lsim(g_sample11, Usim[0, :], Time)
+Yout12, Time, Xsim = lsim(g_sample12, Usim[1, :], Time)
+Yout13, Time, Xsim = lsim(g_sample13, Usim[2, :], Time)
+Yout14, Time, Xsim = lsim(g_sample14, Usim[3, :], Time)
+Yout21, Time, Xsim = lsim(g_sample21, Usim[0, :], Time)
+Yout22, Time, Xsim = lsim(g_sample22, Usim[1, :], Time)
+Yout23, Time, Xsim = lsim(g_sample23, Usim[2, :], Time)
+Yout24, Time, Xsim = lsim(g_sample24, Usim[3, :], Time)
+Yout31, Time, Xsim = lsim(g_sample31, Usim[0, :], Time)
+Yout32, Time, Xsim = lsim(g_sample32, Usim[1, :], Time)
+Yout33, Time, Xsim = lsim(g_sample33, Usim[2, :], Time)
+Yout34, Time, Xsim = lsim(g_sample34, Usim[3, :], Time)
 
 Ytot1 = Yout11 + Yout12 + Yout13 + Yout14 + err_outputH1
 Ytot2 = Yout21 + Yout22 + Yout23 + Yout24 + err_outputH2
@@ -157,7 +169,7 @@ Id_sys = system_identification(Ytot, Usim, 'ARX', ARX_orders=[ordersna, ordersnb
 # output of the identified model
 # you can build g11, g12, etc. separately using the NUMERATOR and DENOMINATOR attributes
 # see how in the armax_MIMO example
-Yout_id, Time, Xsim = cnt.lsim(Id_sys.G, Usim.T, Time)
+Yout_id, Time, Xsim = lsim(Id_sys.G, Usim, Time)
 
 ######plot
 #  


### PR DESCRIPTION
I created a custom `lsim` command in the ARX_MIMO example so the example will work with  `control` 0.8.1 and 0.8.2.